### PR TITLE
Don't overwrite the user loguru config

### DIFF
--- a/loguru_logging_intercept.py
+++ b/loguru_logging_intercept.py
@@ -35,4 +35,3 @@ def setup_loguru_logging_intercept(
         mod_logger = logging.getLogger(logger_name)
         mod_logger.handlers = [InterceptHandler(level=level)]
         mod_logger.propagate = False
-    logger.configure(handlers=[{"sink": sys.stderr, "level": level}])


### PR DESCRIPTION
Don't overwrite the loguru config, so that is is still possible to configure the logger sinks and have this config applied to intercepted logs.

The following code sample
```python
logger.configure(
    handlers=[
        {
            'sink': sys.stderr,
            'format': '[MY OWN LOGGER] {level} : {message}',
            'level': 'INFO'
        }
    ],
)

logger.warning('That is an warning', tid=12345)
logger.info('That is an info', tid=45678)

run_uvicorn_loguru(
    uvicorn.Config(
        "__main__:create_app",
        host="0.0.0.0",
        port=8000,
        log_level="warning",
    )
)
```

produces the following logs, with the current loguru-logging-intercept version. Notice the 2nd warning, generated by uvicorn, using the default loguru format instead of using 'MY OWN LOGGER'.
```
[MY OWN LOGGER] WARNING : That is an warning
[MY OWN LOGGER] INFO : That is an info
2021-04-10 22:43:40.321 | WARNING  | uvicorn.config:load:321 - ASGI app factory detected. Using it, but please consider setting the --factory flag explicitly.
```
With this PR, we get as expected:
```
[MY OWN LOGGER] WARNING : That is an warning
[MY OWN LOGGER] INFO : That is an info
[MY OWN LOGGER] WARNING : ASGI app factory detected. Using it, but please consider setting the --factory flag explicitly.
```
Regarding levels, as far as I understand it, `level` is still used to configure which levels must be generated by the standard logging system, there is no need to configure the loguru logger with this level:
* Uvicorn info logs are hidden as expected
* 'MY OWN LOGGER' is showing the level I'm requesting, in this case, info.
